### PR TITLE
README.md: add glossary section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This section clarifies on terms and abbreviations used in specs and other docume
 - *DPS*[1] - Discovery Partition Specification
 - *UKI*[1] - Unified Kernel Images (sd-stub + kernel + initrd + more)
 - *BLS*[1] - Boot Loader Specification
-- *sysext*[1] – System Extension Image (type of DDI that is overlayed on top of /usr/ via overlayfs and can extend the underlying OS vendor resources in a composable, immutable fashion)
-- *syscfg*[1] – System Configuration Image (type of DDI that is overlayed on top of /etc/ via overlayfs and can extend the underlying OS' configuration in a composable, immutable fashion)
+- *sysext*[1] – System Extension Image (type of DDI that is overlayed on top of `/usr/` and `/opt/` via overlayfs and can extend the underlying OS vendor resources in a composable, immutable fashion)
+- *syscfg*[1] – System Configuration Image (type of DDI that is overlayed on top of `/etc/` via overlayfs and can extend the underlying OS' configuration in a composable, immutable fashion)
 
 [1] *TODO* add reference to spec as soon as it's up at https://github.com/uapi-group/specifications.


### PR DESCRIPTION
This change adds a glossary section to the doc repository's main readme.
The glossary defines terms and abbreviations used in documents throughout the organisation. It may be moved into a separate file if it grows to a point where it overloads the main readme.