### PR TITLE
conferences/: add FOSDEM 2023 devroom and cfp

### DIFF
--- a/conferences/2023-02-04__FOSDEM-devroom.md
+++ b/conferences/2023-02-04__FOSDEM-devroom.md
@@ -1,0 +1,37 @@
+# Image-Based Linux and Secure/Measured Boot Devroom @ FOSDEM 23
+The UAPI group, a community for people with an interest in innovating how we build, deploy, run, and update modern security-focused Linux operating systems, will entertain a devroom at FOSDEM 2023.
+ 
+FOSDEM is a free event for software developers to meet, share ideas and collaborate.
+It takes place on February 4 and 5 at the ULB Solbosch Campus in Brussels, Belgium.
+Learn more at https://fosdem.org/2023/.
+ 
+Our half-day devroom will open on Saturday morning and close at noon.
+Drop in for talks on Image-based Linux and secure / attestable systems, and for a chat with UAPI folks.
+
+<div align="center">
+<h2>Call for Participation</h2>
+We are looking for your talk proposals!<br />
+Talks are <b>20 minutes</b>, on-site.<br />
+<b>CfP deadline is Saturday, Dec 10, 2022.</b>
+</div>
+
+**Topics include**:
+- Image-based Linux distributions: intro, concepts, update, differences with other distros
+- OS and kernel image formats
+- Cross-distro specifications and standards (e.g.: https://uapi-group.org )
+- Trustable boot, device attestation, TPM usage and tooling
+- A/B update implementations
+
+as well as topics related to the above.
+
+**To apply**:
+1. Go to https://penta.fosdem.org/submission/FOSDEM23/event/new and fill in the proposal form.
+   If you don’t have an account yet, create one first.
+2. In the submission form, make sure to select<br />
+   **Track**: “Image-Based Linux and Secure/Measured Boot Devroom”<br />
+   **Event type**: Presentation<br />
+   **Duration**: 20 minutes
+3. Add an abstract to both describe and to promote your talk.
+4. Add / update your speaker bio at https://penta.fosdem.org/submission/FOSDEM23/person 
+
+Proposals will be accepted based on your abstract and speaker bio, please make sure both are in good shape!

--- a/website/content/conferences
+++ b/website/content/conferences
@@ -1,0 +1,1 @@
+../../conferences


### PR DESCRIPTION
This PR adds a new `conferences/` sub folder as well as information and a CfP for the "Image-Based Linux and Secure/Measured Boot Devroom" at FOSDEM 2023.

**Follow-up tasks**
- [ ] Add a short paragraph on the devroom and the CfP as well as a link to the FOSDEM page to the uapi-group landing page (https://github.com/uapi-group/uapi-group.github.io/blob/main/content/_index.md)