### PR TITLE
README, Conferences: add FOSDEM 2023 talks, ASG CfP

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repo contains generic, org-wide documents like meeting minutes.
 
 Listed below are references to the latest UAPI group meeting / conference summaries and minutes.
 
+* [All Systems Go 2023 CfP opened](https://all-systems-go.io/). Check it out and submit your image-based Linux talk proposals today!
+* [FOSDEM 2023 devroom talks and recordings](conferences/2023-02-04__FOSDEM-devroom.md). Alist of talks and links to recordings of the FOSDEM 2023 Image-Based Linux and Secure/Measured Boot devroom.
 * [Summary](minutes/2022-10-05__Image-based-linux-summit.md) of the first Image-Based Linux Summit, October 4th / 5th in Berlin
 
 See the [minutes](https://github.com/uapi-group/docs/tree/main/minutes) folder in the source repository for a full list of documents.

--- a/conferences/2023-02-04__FOSDEM-devroom.md
+++ b/conferences/2023-02-04__FOSDEM-devroom.md
@@ -2,21 +2,35 @@
 The UAPI group, a community for people with an interest in innovating how we build, deploy, run, and update modern security-focused Linux operating systems, will host a devroom at FOSDEM 2023.
 A "devroom" (a FOSDEM term) is a co-located mini-conference with its own separate track.
 
-FOSDEM is a free event for software developers to meet, share ideas and collaborate.
-It takes place on February 4 and 5 at the ULB Solbosch Campus in Brussels, Belgium.
+FOSDEM is an annual free event for software developers to meet, share ideas and collaborate.
+It took place on February 4 and 5 at the ULB Solbosch Campus in Brussels, Belgium.
 Learn more at https://fosdem.org/2023/.
 
-Our half-day devroom will open on Saturday morning at 10.30am and close at 2.30pm.
-Drop in for talks on Image-based Linux and secure / attestable systems, and for a chat with UAPI folks.
-The schedule is [available on the FOSDEM website](https://fosdem.org/2023/schedule/track/image_based_linux_and_secure_measured_boot/).
+**Talks and recordings**
 
-**Topics include**:
-- Image-based Linux distributions: intro, concepts, updates, differences with other distros
-- OS and kernel image formats
-- Cross-distro specifications and standards (e.g.: https://uapi-group.org)
-- Trustable boot, device attestation, TPM usage and tooling
-- A/B update implementations
+Please find talk abstracts, slide decks, and recordings at the FOSDEM pages referenced below.
 
-as well as topics related to the above.
+* [**Devroom kick-off talk: UKI? DDI?? Oh my!!!**](https://fosdem.org/2023/schedule/event/image_linux_secureboot_uki_ddi_ohmy/)
+  *Luca Boccassi*
+  Introducing and decoding image-based Linux terminology and concepts
+* [**DM-Verity Rootfs Protection**](https://fosdem.org/2023/schedule/event/image_linux_secureboot_dmverity/)
+  *Frank Rehberger*
+  Blockwise Hashtree
+* [**Image-Based Linux and TPMs**](https://fosdem.org/2023/schedule/event/image_linux_secureboot_tpm/)
+  *Lennart Poettering*
+  Measured Boot, Protecting Secrets and you
+* [**Building initrds in a new way**](https://fosdem.org/2023/schedule/event/image_linux_secureboot_new_ways_of_initrd_build/)
+  *Zbigniew Jędrzejewski-Szmek*
+* [**Ultrablue**](https://fosdem.org/2023/schedule/event/image_linux_secureboot_ultrablue/)
+  *Gabriel Kerneis*
+  User-friendly Lightweight TPM Remote Attestation over Bluetooth
+* [**Converging image and package based OS updates**](https://fosdem.org/2023/schedule/event/image_linux_secureboot_converging_packages_and_images/)
+  *Ludwig Nussel*
+* [**Ubuntu Core: a technical overview**](https://fosdem.org/2023/schedule/event/image_linux_secureboot_ubuntu_core/)
+  *Valentin David*
+* [**openSUSE MicroOS design**](https://fosdem.org/2023/schedule/event/image_linux_secureboot_suse_micro_os/)
+  *Ignaz Forster*
+  A functional read-only OS in an imperfect world
+* [**MachineOS: a Trusted, SecureBoot Image-based Container OS**](https://fosdem.org/2023/schedule/event/image_linux_secureboot_machineos/)
+  *Ryan Harper*
 
-**Our Call for Papers has closed.**


### PR DESCRIPTION
This PR updates the FOSDEM 2023 conference page to include links to all talks. It updates the index page's FOSDEM 2023 summary and adds a link to the ASG CfP.