### PR TITLE
index / TOC: rename "docs" to "conferences"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-# UAPI Group Generic Documents and Meeting Minutes
+# Conference presentations and Image-Based Linux Summit minutes
 
-This repo contains generic, org-wide documents like meeting minutes.
-
-## Minutes and Summaries
-
-Listed below are references to the latest UAPI group meeting / conference summaries and minutes.
+This repo contains various conference presentations on UAPI group specifications and meeting minutes of our annual Image-Based Linux Summit.
 
 * [Summary](minutes/2024-09-24__Image-based-linux-summit.md) of the third Image-Based Linux Summit, September 24th 2024 in Berlin
 * [All Systems Go 2024 talks and recordings](conferences/2024-09-25__All-Systems-Go.md). Links to recordings of All Systems Go! 2024.
@@ -13,4 +9,4 @@ Listed below are references to the latest UAPI group meeting / conference summar
 * [FOSDEM 2023 devroom talks and recordings](conferences/2023-02-04__FOSDEM-devroom.md). A list of talks and links to recordings of the FOSDEM 2023 Image-Based Linux and Secure/Measured Boot devroom.
 * [Summary](minutes/2022-10-05__Image-based-linux-summit.md) of the first Image-Based Linux Summit, October 4th / 5th in Berlin
 
-See the [minutes](https://github.com/uapi-group/docs/tree/main/minutes) folder in the source repository for a full list of documents.
+See the [minutes](https://github.com/uapi-group/conferences/tree/main/minutes) folder in the source repository for a full list of documents.

--- a/website/config.toml
+++ b/website/config.toml
@@ -1,6 +1,6 @@
-baseURL = "https://uapi-group.org/docs"
+baseURL = "https://uapi-group.org/conferences"
 languageCode = "en-us"
-title = "UAPI group generic documents and meeting minutes"
+title = "Conferences and Minutes"
 theme = "hugo-book"
 
 [[menu.before]]
@@ -10,7 +10,7 @@ theme = "hugo-book"
 
 [[menu.after]]
   name = "Collaborate on Github"
-  url = "https://github.com/uapi-group/docs"
+  url = "https://github.com/uapi-group/conferences"
   weight = 11
 
 [markup.goldmark.renderer]
@@ -19,7 +19,7 @@ theme = "hugo-book"
 [params]
   BookPortableLinks = true
   BookSection = '*'
-  BookRepo = 'https://github.com/uapi-group/docs'
+  BookRepo = 'https://github.com/uapi-group/conferences'
   BookCommitPath = 'commit'
   BookEditLink = '{{ .Site.Params.BookRepo }}/edit/main/{{ .Path }}'
   BookIndexPage = 'README.md'


### PR DESCRIPTION
This change renames references to the "docs" repository to "conferences". "docs" really only ever contained references to conferences talks and meeting minutes of our annual Immutable Linux summits.

**NOTE** that this requires us to rename this repository to "conferences" after merge, or links to "conferences" at https://uapi-group.org will break.

Related: https://github.com/uapi-group/uapi-group.github.io/pull/23